### PR TITLE
Added correct Travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ShowGo :notes: [![Build Status](https://travis-ci.org/addisonverger/Phase-1-Group-Project.svg?branch=master)](https://travis-ci.org/addisonverger/Phase-1-Group-Project)
+# ShowGo :notes: [[![Build Status](https://travis-ci.com/addisonverger/Phase-1-Group-Project.svg?branch=master)](https://travis-ci.com/addisonverger/Phase-1-Group-Project)
 ## Where you can find out when your favorite artist is coming to town and when similar artists are playing  :guitar: metal:
 
 ### Hosting


### PR DESCRIPTION
Updated Travis badge to point to .com site instead of .org site. Should now show correct status